### PR TITLE
Add us-central1 to region codes in TaskQueue Client

### DIFF
--- a/src/A1comms/GaeSupportLaravel/Integration/TaskQueue/Client.php
+++ b/src/A1comms/GaeSupportLaravel/Integration/TaskQueue/Client.php
@@ -57,6 +57,9 @@ class Client
             case "eu6":
                 return "europe-west1";
                 break;
+            case "us14":
+                return "us-central1";
+                break;
             default:
                 throw new Exception("Unknown App Engine Region Code: " . $zone);
                 break;


### PR DESCRIPTION
Hello,

When trying to throw tasks onto the queue, I was hit with an error that basically meant that this package didn't know how to translate the GAE region code into an actual region.

I see that you have entries for Europe, but none of the US. I attempted to find a list of GAE region codes so I could just add all of them for you but I failed to find any. So I just listed us14 from my log entries, which translates to us-central1.

This fixed my issue and allowed me to get tasks onto the Cloud Tasks queue. But I still can't run them.

Anyway, thanks again! If you can point me to a list of all region codes, I will make a new PR with the entire list.