### PR TITLE
Compress queue

### DIFF
--- a/docs/queue.md
+++ b/docs/queue.md
@@ -22,6 +22,7 @@ You'll then need to add a driver entry into `config/queue.php`:
             'queue'     => 'default',
             'url'       => '/tasks',
             'encrypt'   => true,
+            'compress'  => true,
         ),
     ],
 ```

--- a/src/A1comms/GaeSupportLaravel/Queue/GaeConnector.php
+++ b/src/A1comms/GaeSupportLaravel/Queue/GaeConnector.php
@@ -2,9 +2,10 @@
 
 namespace A1comms\GaeSupportLaravel\Queue;
 
+use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Illuminate\Http\Request;
 use Illuminate\Queue\Connectors\ConnectorInterface;
-use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
+use Illuminate\Support\Arr;
 
 class GaeConnector implements ConnectorInterface
 {
@@ -22,15 +23,16 @@ class GaeConnector implements ConnectorInterface
      */
     protected $request;
 
-
     /**
      * Create a new GAE connector instance.
      *
      * @param \Illuminate\Contracts\Encryption\Encrypter $crypt
      * @param \Illuminate\Http\Request $request
      */
-    public function __construct(EncrypterContract $crypt, Request $request)
-    {
+    public function __construct(
+        EncrypterContract $crypt,
+        Request $request
+    ) {
         $this->crypt = $crypt;
         $this->request = $request;
     }
@@ -38,11 +40,18 @@ class GaeConnector implements ConnectorInterface
     /**
      * Establish a queue connection.
      *
-     * @param  array  $config
+     * @param array $config
+     *
      * @return \Illuminate\Queue\QueueInterface
      */
     public function connect(array $config)
     {
-        return new GaeQueue($this->request, $config['queue'], $config['url'], $config['encrypt']);
+        return new GaeQueue(
+            $this->request,
+            $config['queue'],
+            $config['url'],
+            (bool) Arr::get($config, 'encrypt'),
+            (bool) Arr::get($config, 'compress')
+        );
     }
 }


### PR DESCRIPTION
I ran into many issues trying to use `::withChain` and the resulting large queue size. Adding an option to compress the queue appears to mitigate this issue without a dramatic increase in processing time.