### PR TITLE
BUGFIX: Update ApplicationBuilder Namespace.

### DIFF
--- a/src/AffordableMobiles/GServerlessSupportLaravel/Foundation/Configuration/ApplicationBuilder.php
+++ b/src/AffordableMobiles/GServerlessSupportLaravel/Foundation/Configuration/ApplicationBuilder.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AffordableMobiles\GServerlessSupportLaravel\Foundation;
+namespace AffordableMobiles\GServerlessSupportLaravel\Foundation\Configuration;
 
 use AffordableMobiles\GServerlessSupportLaravel\Integration\ErrorReporting\Report;
 use Illuminate\Foundation\Application;


### PR DESCRIPTION
Update ApplicationBuilder namespace - Fixing:

> PHP Notice: Error: Class "AffordableMobiles\GServerlessSupportLaravel\Foundation\Configuration\ApplicationBuilder" not found