### PR TITLE
Fallback to the default exception handler outside of serverless

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
     },
     "config": {
         "allow-plugins": {
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "tbachert/spi": true
         }
     }
 }

--- a/src/AffordableMobiles/GServerlessSupportLaravel/Auth/IdentityGroupUserProvider.php
+++ b/src/AffordableMobiles/GServerlessSupportLaravel/Auth/IdentityGroupUserProvider.php
@@ -76,7 +76,7 @@ class IdentityGroupUserProvider extends NullUserProvider
             return (new CloudIdentity($client))->groups_memberships->checkTransitiveMembership(
                 'groups/'.$this->group,
                 [
-                    'query' => sprintf("member_key_id == '%s'", $identifier),
+                    'query' => \sprintf("member_key_id == '%s'", $identifier),
                 ],
             )->getHasMembership();
         } catch (\Throwable $ex) {

--- a/src/AffordableMobiles/GServerlessSupportLaravel/Auth/Token/Middleware/AuthTokenMiddleware.php
+++ b/src/AffordableMobiles/GServerlessSupportLaravel/Auth/Token/Middleware/AuthTokenMiddleware.php
@@ -124,7 +124,7 @@ class AuthTokenMiddleware
 
         $audienceSource = static function (UriInterface $request_uri) use ($audienceMap) {
             if (self::isCloudFunction($request_uri)) {
-                return sprintf(
+                return \sprintf(
                     '%s://%s%s',
                     $request_uri->getScheme(),
                     $request_uri->getHost(),

--- a/src/AffordableMobiles/GServerlessSupportLaravel/Console/GServerlessViewCompileCommand.php
+++ b/src/AffordableMobiles/GServerlessSupportLaravel/Console/GServerlessViewCompileCommand.php
@@ -90,7 +90,7 @@ class GServerlessViewCompileCommand extends Command
                 $filePath         = $file->getPathname();
                 $fileRelativePath = FileViewFinder::getRelativePath(base_path(), $filePath);
 
-                if (!preg_match('/(.*)\\.blade\\.php$/', $filePath)) {
+                if (!preg_match('/(.*)\.blade\.php$/', $filePath)) {
                     $this->info("Blade Compiler: \tSkipping view (".($g + 1).'/'.\count($files).') '.$fileRelativePath);
 
                     continue;

--- a/src/AffordableMobiles/GServerlessSupportLaravel/Foundation/Exceptions/Handler.php
+++ b/src/AffordableMobiles/GServerlessSupportLaravel/Foundation/Exceptions/Handler.php
@@ -19,6 +19,12 @@ class Handler extends LaravelHandler
      */
     protected function reportThrowable(\Throwable $e): void
     {
+        if (!is_g_serverless()) {
+            parent::reportThrowable($e);
+
+            return;
+        }
+
         $this->reportedExceptionMap[$e] = true;
 
         if (Reflector::isCallable($reportCallable = [$e, 'report'])

--- a/src/AffordableMobiles/GServerlessSupportLaravel/Integration/ErrorReporting/Report.php
+++ b/src/AffordableMobiles/GServerlessSupportLaravel/Integration/ErrorReporting/Report.php
@@ -42,7 +42,7 @@ class Report
 
     public static function exceptionHandler(\Throwable $ex, int $status_code = 500, array $context = [], string $level = LogLevel::ERROR): void
     {
-        $message = sprintf('PHP Notice: %s', (string) $ex);
+        $message = \sprintf('PHP Notice: %s', (string) $ex);
         if (self::$psrLogger) {
             $logContext = [
                 'context' => array_merge($context, [
@@ -86,7 +86,7 @@ class Report
         if (!($level & error_reporting())) {
             return true;
         }
-        $message = sprintf(
+        $message = \sprintf(
             '%s: %s in %s on line %d',
             self::getErrorPrefix($level),
             $message,
@@ -139,7 +139,7 @@ class Report
                 case E_PARSE:
                 case E_COMPILE_ERROR:
                 case E_CORE_ERROR:
-                    $message = sprintf(
+                    $message = \sprintf(
                         '%s: %s in %s on line %d',
                         self::getErrorPrefix($err['type']),
                         $err['message'],

--- a/src/AffordableMobiles/GServerlessSupportLaravel/Integration/JWT/Signer/IAMSigner.php
+++ b/src/AffordableMobiles/GServerlessSupportLaravel/Integration/JWT/Signer/IAMSigner.php
@@ -75,7 +75,7 @@ class IAMSigner implements Signer
 
         $service = new \Google_Service_IAMCredentials($client);
 
-        $keyID = sprintf('projects/-/serviceAccounts/%s', $key->contents());
+        $keyID = \sprintf('projects/-/serviceAccounts/%s', $key->contents());
 
         $requestBody = new \Google_Service_IAMCredentials_SignBlobRequest();
 

--- a/src/AffordableMobiles/GServerlessSupportLaravel/Session/DatastoreSessionHandler.php
+++ b/src/AffordableMobiles/GServerlessSupportLaravel/Session/DatastoreSessionHandler.php
@@ -63,7 +63,7 @@ class DatastoreSessionHandler implements \SessionHandlerInterface
             }
         } catch (Exception $e) {
             trigger_error(
-                sprintf('Datastore lookup failed: %s', $e->getMessage()),
+                \sprintf('Datastore lookup failed: %s', $e->getMessage()),
                 E_USER_WARNING
             );
         }
@@ -88,7 +88,7 @@ class DatastoreSessionHandler implements \SessionHandlerInterface
                 (new ExponentialBackoff(6, [DatastoreFactory::class, 'shouldRetry']))->execute([$this->datastore, 'upsert'], [$entity]);
             } catch (Exception $e) {
                 trigger_error(
-                    sprintf('Datastore upsert failed: %s', $e->getMessage()),
+                    \sprintf('Datastore upsert failed: %s', $e->getMessage()),
                     E_USER_WARNING
                 );
 
@@ -106,7 +106,7 @@ class DatastoreSessionHandler implements \SessionHandlerInterface
             (new ExponentialBackoff(6, [DatastoreFactory::class, 'shouldRetry']))->execute([$this->datastore, 'delete'], [$key]);
         } catch (Exception $e) {
             trigger_error(
-                sprintf('Datastore delete failed: %s', $e->getMessage()),
+                \sprintf('Datastore delete failed: %s', $e->getMessage()),
                 E_USER_WARNING
             );
 

--- a/src/AffordableMobiles/GServerlessSupportLaravel/Trace/Instrumentation/Datastore/GDS/GDSInstrumentation.php
+++ b/src/AffordableMobiles/GServerlessSupportLaravel/Trace/Instrumentation/Datastore/GDS/GDSInstrumentation.php
@@ -23,7 +23,7 @@ class GDSInstrumentation implements InstrumentationInterface
             Gateway::class,
             'execute',
             pre: static function (Gateway $client, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation): void {
-                SimpleSpan::pre($instrumentation, sprintf('GDS/execute/%s', $params[0] ?? 'unknown'), []);
+                SimpleSpan::pre($instrumentation, \sprintf('GDS/execute/%s', $params[0] ?? 'unknown'), []);
             },
             post: static function (Gateway $client, array $params, mixed $returnValue, ?\Throwable $exception): void {
                 SimpleSpan::post();
@@ -67,7 +67,7 @@ class GDSInstrumentation implements InstrumentationInterface
             GatewayREST::class,
             'executePostRequest',
             pre: static function (GatewayREST $client, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation): void {
-                SimpleSpan::pre($instrumentation, sprintf('GDS/execute/%s', $params[0] ?? 'unknown'), []);
+                SimpleSpan::pre($instrumentation, \sprintf('GDS/execute/%s', $params[0] ?? 'unknown'), []);
             },
             post: static function (GatewayREST $client, array $params, mixed $returnValue, ?\Throwable $exception): void {
                 SimpleSpan::post();

--- a/src/AffordableMobiles/GServerlessSupportLaravel/Trace/Instrumentation/Guzzle/GuzzleInstrumentation.php
+++ b/src/AffordableMobiles/GServerlessSupportLaravel/Trace/Instrumentation/Guzzle/GuzzleInstrumentation.php
@@ -64,7 +64,7 @@ class GuzzleInstrumentation implements InstrumentationInterface
                 foreach (array_filter(explode('|', env('TRACE_GUZZLE_HTTP_REQUEST_HEADERS', ''))) as $header) {
                     if ($request->hasHeader($header)) {
                         $spanBuilder->setAttribute(
-                            sprintf('http.request.header.%s', strtolower($header)),
+                            \sprintf('http.request.header.%s', strtolower($header)),
                             $request->getHeader($header)
                         );
                     }
@@ -124,7 +124,7 @@ class GuzzleInstrumentation implements InstrumentationInterface
                         foreach (array_filter(explode('|', env('TRACE_GUZZLE_HTTP_RESPONSE_HEADERS', ''))) as $header) {
                             if ($response->hasHeader($header)) {
                                 // @psalm-suppress ArgumentTypeCoercion
-                                $span->setAttribute(sprintf('http.response.header.%s', strtolower($header)), $response->getHeader($header));
+                                $span->setAttribute(\sprintf('http.response.header.%s', strtolower($header)), $response->getHeader($header));
                             }
                         }
                         if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 600) {

--- a/src/AffordableMobiles/GServerlessSupportLaravel/Trace/Instrumentation/Laravel/HttpInstrumentation.php
+++ b/src/AffordableMobiles/GServerlessSupportLaravel/Trace/Instrumentation/Laravel/HttpInstrumentation.php
@@ -31,7 +31,7 @@ class HttpInstrumentation implements InstrumentationInterface
 
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = $instrumentation->tracer()
-                    ->spanBuilder(sprintf('%s', $request?->method() ?? 'unknown'))
+                    ->spanBuilder(\sprintf('%s', $request?->method() ?? 'unknown'))
                     ->setSpanKind(SpanKind::KIND_SERVER)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)
                     ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)


### PR DESCRIPTION
Fall back to the default exception handler when not running on a serverless platform.

This was the expected behaviour, but was missed in the upgrade to the latest Laravel version.